### PR TITLE
Add Toggle Functionality for BibTeX and Normal Citations

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,6 @@
 from flask import redirect, render_template, request, jsonify, flash
 from db_helper import reset_db
-from repositories.citation_repository import get_citations, create_todo, set_done, create_citation
+from repositories.citation_repository import get_citations, create_todo, set_done, create_citation, generate_bibtex
 from config import app, test_env
 from util import validate_todo
 
@@ -30,7 +30,13 @@ def create_new():
 
     return render_template('index.html', citations=citations)
 
+@app.route('/toggle-bibtex')
+def toggle_bibtex():
+    print("toggle-bibtex here!")
+    citations = get_citations()
 
+    bibtex_citations = generate_bibtex(citations)
+    return render_template('index.html', citations=bibtex_citations)
 
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -36,7 +36,7 @@ def toggle_bibtex():
     citations = get_citations()
 
     bibtex_citations = generate_bibtex(citations)
-    return render_template('index.html', citations=bibtex_citations)
+    return render_template('index.html', citations=bibtex_citations, is_bibtex=True)
 
 
 

--- a/src/repositories/citation_repository.py
+++ b/src/repositories/citation_repository.py
@@ -30,3 +30,22 @@ def create_citation(key, author, title, journal, year, volume, pages):
     db.session.execute(sql, {'key': key, 'author': author, 'title': title, 'journal': journal, 'year': year, 'volume': volume, 'pages': pages})
     db.session.commit()
     return
+
+def generate_bibtex(citations):
+    bibtex_citations = []
+    for c in citations:
+        if type(c) == Article:
+            bibtex_c = f"@article{{{c.key},\n" \
+                           f"    author = {{{c.author}}},\n" \
+                           f"    title = {{{c.title}}},\n" \
+                           f"    journal = {{{c.journal}}},\n" \
+                           f"    year = {{{c.year}}},\n" \
+                           f"    volume = {{{c.volume}}},\n" \
+                           f"    pages = {{{c.pages}}}\n" \
+                           f"}}"
+            bibtex_citations.append(bibtex_c)
+        # if type(c) == Inproceedings:
+        #     print("Inproceedings it is!")
+        # if type(c) == Book:
+        #     print("Book it is!")
+    return bibtex_citations

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,23 +1,21 @@
-{% extends "layout.html" %}
+{% extends "layout.html" %} {% block title %}Bibtex-apuri{% endblock %} {% block
+body %}
 
-{% block title %}Bibtex-apuri{% endblock %}
+<h1>Bibtex-apuri</h1>
+<form action="/toggle-bibtex" method="GET">
+  <button type="submit">Toggle BibTeX</button>
+</form>
 
-{% block body %}
+<pre>
+{% for citation in citations %}
+{{citation}}
+{% else %}
+<p>Ei lisättyjä viitteitä</p>
+{% endfor %}
+</pre>
 
-  <h1>Bibtex-apuri</h1>
+<br />
 
-  {% for citation in citations %}
-
-    <p><strong>*</strong> {{citation}}</p>
-
-  {% else %}
-
-    <p>Ei lisättyjä viitteitä</p>
-
-  {% endfor %}
-
-  <br>
-
-  <a href="/new">Luo uusi viite</a>
+<a href="/new">Luo uusi viite</a>
 
 {% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -2,9 +2,16 @@
 body %}
 
 <h1>Bibtex-apuri</h1>
+
+{% if not is_bibtex %}
 <form action="/toggle-bibtex" method="GET">
   <button type="submit">Toggle BibTeX</button>
 </form>
+{% else %}
+<form action="/" method="GET">
+  <button type="submit">Toggle normal citations</button>
+</form>
+{% endif %}
 
 <pre>
 {% for citation in citations %}


### PR DESCRIPTION
This allows users to toggle between BibTeX and normal citation formats. It includes a new route for switching formats and updates the index.py template to conditionally render the appropriate toggle button.

