### PR TITLE
do not center text in bibtex mode

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -76,3 +76,8 @@ nav li:hover {
   align-items: center;
 
 }
+
+pre {
+  width: 100%;
+  max-width: 400px;
+}


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/f2b50ed9-ca51-42db-bd5e-133c542ea4b4)

after:

![image](https://github.com/user-attachments/assets/eee1ac55-8ac5-41ac-8840-b49e4fb17ded)