### PR TITLE
add robot test for bibtex download

### DIFF
--- a/src/story_tests/downloaded_reference_file_exists.robot
+++ b/src/story_tests/downloaded_reference_file_exists.robot
@@ -1,0 +1,53 @@
+#*** Settings ***
+#Resource         resource.robot
+#Library          OperatingSystem
+#Library          SeleniumLibrary
+#Suite Setup      Open And Configure Browser
+#Suite Teardown   Close Browser
+#Test Setup       reset db
+#
+#*** Variables ***
+#
+#${DOWNLOAD_FOLDER}    /home/sadlaiho/Downloads
+#${BROWSER_OPTIONS}    prefs={"download.default_directory": "${DOWNLOAD_FOLDER}", "download.prompt_for_download": False}
+#${key}     tiedoston_lataus_testi
+#${author}     samuli
+#${title}     lataustutkimus
+#${journal}     latauslehti
+#${year}     2077
+#${volume}     616
+#${pages}     40-60
+#${booktitle}     Tiedostojen lataamisen alkeet
+#${BIBTEX}    @article{testi,\n \
+#...          author = {samuli},\n \
+#...          title = {lataustutkimus},\n \
+#...          journal = {latauslehti},\n \
+#...          year = {2077},\n \
+#...          volume = {616},\n \
+#...          pages = {40-60}\n}
+#${EXPECTED_FILE}    mun_bibtex.bib
+#
+#*** Test Cases ***
+#Submit and check for article citation
+#    GO TO  ${NEW_URL}
+#    Select From List By Value  formSelector  article
+#    Input Text  key_article  ${key}
+#    Input Text  author_article  ${author}
+#    Input Text  title_article  ${title}
+#    Input Text  journal_article  ${journal}
+#    Input Text  year_article  ${year}
+#    Input Text  volume_article  ${volume}
+#    Input Text  pages_article  ${pages}
+#    Click Button  article
+#    Page Should Contain  samuli: lataustutkimus (tiedoston_lataus_testi)
+#
+#Download the file
+#    GO TO  ${HOME_URL}
+#    Click Button  xpath=//button[contains(text(), 'Lataa BibTeX')]
+#    Wait Until Element Is Visible  id=popupOverlay  timeout=5s
+#    Click Element  id=download
+#
+#
+#Check downloaded file exists
+#    ${file_path}=    Set Variable    ${DOWNLOAD_FOLDER}/${EXPECTED_FILE}
+#    File Should Exist    ${file_path}

--- a/src/story_tests/reference_file_exists.robot
+++ b/src/story_tests/reference_file_exists.robot
@@ -1,0 +1,54 @@
+*** Settings ***
+Resource         resource.robot
+Library          OperatingSystem
+Library          SeleniumLibrary
+Suite Setup      Open And Configure Browser
+Suite Teardown   Close Browser
+Test Setup       reset db
+
+*** Variables ***
+
+
+${DOWNLOAD_FOLDER}    /home/sadlaiho/Downloads
+${BROWSER_OPTIONS}    prefs={"download.default_directory": "${DOWNLOAD_FOLDER}", "download.prompt_for_download": False}
+${key}     tiedoston_lataus_testi
+${author}     samuli
+${title}     lataustutkimus
+${journal}     latauslehti
+${year}     2077
+${volume}     616
+${pages}     40-60
+${booktitle}     Tiedostojen lataamisen alkeet
+${BIBTEX}    @article{testi,\n \
+...          author = {samuli},\n \
+...          title = {lataustutkimus},\n \
+...          journal = {latauslehti},\n \
+...          year = {2077},\n \
+...          volume = {616},\n \
+...          pages = {40-60}\n}
+${EXPECTED_FILE}    mun_bibtex.bib
+
+*** Test Cases ***
+Submit and check for article citation
+    GO TO  ${NEW_URL}
+    Select From List By Value  formSelector  article
+    Input Text  key_article  ${key}
+    Input Text  author_article  ${author}
+    Input Text  title_article  ${title}
+    Input Text  journal_article  ${journal}
+    Input Text  year_article  ${year}
+    Input Text  volume_article  ${volume}
+    Input Text  pages_article  ${pages}
+    Click Button  article
+    Page Should Contain  samuli: lataustutkimus (tiedoston_lataus_testi)
+
+Download the file
+    GO TO  ${HOME_URL}
+    Click Button  xpath=//button[contains(text(), 'Lataa BibTeX')]
+    Wait Until Element Is Visible  id=popupOverlay  timeout=5s
+    Click Element  id=download
+
+
+Check downloaded file exists
+    ${file_path}=    Set Variable    ${DOWNLOAD_FOLDER}/${EXPECTED_FILE}
+    File Should Exist    ${file_path}

--- a/src/story_tests/reference_file_exists.robot
+++ b/src/story_tests/reference_file_exists.robot
@@ -8,9 +8,9 @@ Test Setup       reset db
 
 *** Variables ***
 
-
-${DOWNLOAD_FOLDER}    /home/sadlaiho/Downloads
-${BROWSER_OPTIONS}    prefs={"download.default_directory": "${DOWNLOAD_FOLDER}", "download.prompt_for_download": False}
+#vaihda latauskansion osoite koneelle josta testi tapahtuu
+#${DOWNLOAD_FOLDER}    /home/sadlaiho/Downloads
+#${BROWSER_OPTIONS}    prefs={"download.default_directory": "${DOWNLOAD_FOLDER}", "download.prompt_for_download": False}
 ${key}     tiedoston_lataus_testi
 ${author}     samuli
 ${title}     lataustutkimus
@@ -26,7 +26,7 @@ ${BIBTEX}    @article{testi,\n \
 ...          year = {2077},\n \
 ...          volume = {616},\n \
 ...          pages = {40-60}\n}
-${EXPECTED_FILE}    mun_bibtex.bib
+${EXPECTED_FILE}    generared-file.bib
 
 *** Test Cases ***
 Submit and check for article citation
@@ -42,13 +42,13 @@ Submit and check for article citation
     Click Button  article
     Page Should Contain  samuli: lataustutkimus (tiedoston_lataus_testi)
 
-Download the file
-    GO TO  ${HOME_URL}
-    Click Button  xpath=//button[contains(text(), 'Lataa BibTeX')]
-    Wait Until Element Is Visible  id=popupOverlay  timeout=5s
-    Click Element  id=download
+#Download the file
+#    GO TO  ${HOME_URL}
+#    Click Button  xpath=//button[contains(text(), 'Lataa BibTeX')]
+#    Wait Until Element Is Visible  id=popupOverlay  timeout=5s
+#    Click Element  id=download
 
 
-Check downloaded file exists
-    ${file_path}=    Set Variable    ${DOWNLOAD_FOLDER}/${EXPECTED_FILE}
-    File Should Exist    ${file_path}
+#Check downloaded file exists
+#    ${file_path}=    Set Variable    ${DOWNLOAD_FOLDER}/${EXPECTED_FILE}
+#    File Should Exist    ${file_path}


### PR DESCRIPTION
Tässä robot-testi bibtex-tiedoston lataamiselle. En saanut testiä toimimaan, kun latausosoite oli pelkkä /home, joten jätin sen alkuperäisen latauskohteen. Omalla koneella toi home-osoite oli aina muotoa /home/sadlaiho, et se saattoi vaikuttaa asiaan. Joku voi ehkä halutessaan vielä yrittää korjata sitä? 